### PR TITLE
Actually computes PI

### DIFF
--- a/Numbers/pi.py
+++ b/Numbers/pi.py
@@ -1,10 +1,20 @@
 # Find PI to the Nth Digit
 
-from math import *
+from __future__ import division
 
-digits = raw_input('Enter number of digits to round PI to: ')
 
-# print ('{0:.%df}' % min(20, int(digits))).format(math.pi) # nested string formatting
+digits = raw_input("Enter number of digits to round PI to: ")
+digits = int(digits)
 
-# calculate pi using Machin-like Formula
-print ('{0:.%df}' % min(30, int(digits))).format(4 * (4 * atan(1.0/5.0) - atan(1.0/239.0)))
+# n-th term is < 10^-(2*n + 1)
+# so n iterations gives you 2*n digits
+iterations = digits//2 + 2
+
+# pi = 4*(4*atan(1/5) - atan(1/239))
+# atan(x) = sum(x=0..+inf, (-1)^n / (2*n + 1))
+pi = 0
+
+for n in xrange(iterations):
+    pi += 4 * (4 * (-1)**n/(2*n + 1) * (1/5)**(2*n + 1) - (-1)**n/(2*n + 1) * (1/239)**(2*n + 1))
+
+print("{{:.{}}}".format(digits + 1).format(pi))


### PR DESCRIPTION
Using `math.atan()` is of course cheating; it is using the answer to compute it. If `math` is allowed, we might as well do `4*atan(1)` or just simply `math.pi`.

This can certainly be optimized, if anyone cares.
